### PR TITLE
FIX: datetime fields

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
       - uses: actions/checkout@v3

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,10 @@
 ## Release Notes ##
+**Version 1.0.3 (compatible with SurrealDB version 2.0.4):**
+- fix datetime bug for fields (prefix d')
+- add tests, examples and docs for datetimes
+- add test runs for Python 3.13
+
+
 **Version 1.0.2 (compatible with SurrealDB version 2.0.2):**
 - minor fixes
 

--- a/examples/changes_feed.py
+++ b/examples/changes_feed.py
@@ -6,7 +6,7 @@ from surrealist import Surreal
 surreal = Surreal("http://127.0.0.1:8000", namespace="test", database="test", credentials=("user_db", "user_db"))
 with surreal.connect() as connection:
     connection.query('CREATE reading set story = "long long time ago";')  # create change on reading table
-    dt = "2024-02-06T12:25:48.700483Z"  # assume this moment is AFTER foo and reading were created
-    res = connection.show_changes('reading', "2024-02-06T12:25:48.700483Z")
+    dt = "d'2024-02-06T12:25:48.700483Z'"  # assume this moment is AFTER foo and reading were created
+    res = connection.show_changes('reading', dt)
     print(res.result)
     # [{'changes': [{'update': {'id': 'reading:w0useg3n9bkne6mei63f', 'story': 'long long time ago'}}]

--- a/examples/surreal_ql/ql_show_examples.py
+++ b/examples/surreal_ql/ql_show_examples.py
@@ -12,10 +12,10 @@ with Database("http://127.0.0.1:8000", 'test', 'test', credentials=('user_db', '
 
     tm = to_surreal_datetime_str(datetime.now(timezone.utc))  # get current time in surreal format
 
-    # SHOW CHANGES FOR TABLE person SINCE "2023-09-07T01:23:52Z";
+    # SHOW CHANGES FOR TABLE person SINCE d"2023-09-07T01:23:52Z";
     print(db.table("person").show_changes().since(tm))
     print(db.table("person").show_changes(since=tm))
 
-    # SHOW CHANGES FOR TABLE person SINCE "2023-09-07T01:23:52Z" LIMIT 10;
-    print(db.person.show_changes().since("2023-09-07T01:23:52Z").limit(10))
-    print(db.person.show_changes(since="2023-09-07T01:23:52Z").limit(10))
+    # SHOW CHANGES FOR TABLE person SINCE "d'2023-09-07T01:23:52Z'" LIMIT 10;
+    print(db.person.show_changes().since("d'2023-09-07T01:23:52Z'").limit(10))
+    print(db.person.show_changes(since="d'2023-09-07T01:23:52Z'").limit(10))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "surrealist"
-version = "1.0.2"
+version = "1.0.3"
 description = "Python client for SurrealDB, latest SurrealDB version compatible, all features supported"
 readme = "README.md"
 authors = [{ name = "kotolex", email = "farofwell@gmail.com" }]

--- a/src/surrealist/connections/connection.py
+++ b/src/surrealist/connections/connection.py
@@ -6,7 +6,7 @@ from typing import Tuple, Dict, Optional, Union, List, Callable, Any
 
 from surrealist.errors import OperationOnClosedConnectionError, TooManyNestedLevelsError, WrongParameterError
 from surrealist.result import SurrealResult
-from surrealist.utils import DEFAULT_TIMEOUT, crop_data, NS, DB, AC, mask_pass
+from surrealist.utils import DEFAULT_TIMEOUT, crop_data, NS, DB, AC, mask_pass, clean_dates
 
 logger = getLogger("surrealist.connection")
 LINK = "https://github.com/kotolex/surrealist?tab=readme-ov-file#recursion-and-json-in-python"
@@ -248,11 +248,11 @@ class Connection(ABC):
         Refer to: https://github.com/kotolex/surrealist?tab=readme-ov-file#change-feeds
 
         :param table_name: name of the table, no record_id expected here
-        :param since: str representation of ISO date-time, for example "2024-02-06T10:48:08.700483Z"
+        :param since: str representation of ISO date-time, for example d"2024-02-06T10:48:08.700483Z"
         :param limit: amount of changes to get
         :return: result of the query
         """
-        query = f'SHOW CHANGES FOR TABLE {table_name} SINCE d"{since}" LIMIT {limit};'
+        query = f'SHOW CHANGES FOR TABLE {table_name} SINCE {since} LIMIT {limit};'
         return self.query(query)
 
     @abstractmethod
@@ -720,6 +720,7 @@ class Connection(ABC):
         :param variables: a set of variables used by the query
         :return: result of request
         """
+        query = clean_dates(query)
         params = [query]
         if variables is not None:
             params.append(variables)

--- a/src/surrealist/utils.py
+++ b/src/surrealist/utils.py
@@ -55,17 +55,30 @@ def crop_data(data: Union[str, bytes], is_str: bool = True) -> Union[str, bytes]
 
 def to_surreal_datetime_str(dt: datetime.datetime) -> str:
     """
-    Convert datetime to string in Surreal format, for example: 2024-04-18T11:34:41.665249Z
+    Convert datetime to string in Surreal format, for example: d'2024-04-18T11:34:41.665249Z'
     :param dt: datetime object
     :return: string representation of the datetime
     """
-    return dt.strftime(DATE_FORMAT_NS)
+    return f"d'{dt.strftime(DATE_FORMAT_NS)}'"
 
 
 def to_datetime(dt_str: str) -> datetime.datetime:
     """
     Convert string in Surreal format to datetime object
-    :param dt_str: string datetime representation in Surreal format (e.g. 2024-04-18T11:34:41.665249Z)
+    :param dt_str: string datetime representation in Surreal format (e.g. d'2024-04-18T11:34:41.665249Z')
     :return: datetime object
     """
+    if "d'" in dt_str:
+        dt_str = dt_str.rstrip("'").replace("d'", "")
+    elif 'd"' in dt_str:
+        dt_str = dt_str.rstrip('"').replace('d"', '')
     return datetime.datetime.strptime(dt_str, DATE_FORMAT_NS)
+
+
+def clean_dates(data: str) -> str:
+    """
+    Get surreal dates with d' prefix out of quotes
+    :param data: some Surreal query
+    :return: data with valid Surreal dates
+    """
+    return re.sub(r'["\'](d(["\']).+?)["\']+', r'\1\2', data)

--- a/tests/unit_tests/test_ql_show.py
+++ b/tests/unit_tests/test_ql_show.py
@@ -9,31 +9,31 @@ class TestShow(TestCase):
         self.assertTrue("SHOW CHANGES FOR TABLE person SINCE " in show.to_str())
 
     def test_create_since(self):
-        show = Show(None, "person").since("2023-09-07T01:23:52Z")
+        show = Show(None, "person").since('d"2023-09-07T01:23:52Z"')
         self.assertEqual('SHOW CHANGES FOR TABLE person SINCE d"2023-09-07T01:23:52Z";', show.to_str())
         self.assertTrue(show.is_valid())
-        show = Show(None, "person").since("2024-02-06T10:48:08.700483Z")
-        self.assertEqual('SHOW CHANGES FOR TABLE person SINCE d"2024-02-06T10:48:08.700483Z";', show.to_str())
+        show = Show(None, "person").since('d"2023-09-07T01:23:52Z"')
+        self.assertEqual('SHOW CHANGES FOR TABLE person SINCE d"2023-09-07T01:23:52Z";', show.to_str())
         self.assertTrue(show.is_valid())
 
     def test_invalid_since(self):
-        show = Show(None, "person").since("2023-09-07")
-        self.assertEqual('SHOW CHANGES FOR TABLE person SINCE d"2023-09-07";', show.to_str())
+        show = Show(None, "person").since('2023-09-07')
+        self.assertEqual('SHOW CHANGES FOR TABLE person SINCE 2023-09-07;', show.to_str())
         self.assertFalse(show.is_valid())
 
     def test_full_query(self):
         show = Show(None, "person").since("2023-09-07T01:23:52Z").limit(10)
-        self.assertEqual('SHOW CHANGES FOR TABLE person SINCE d"2023-09-07T01:23:52Z" LIMIT 10;', show.to_str())
+        self.assertEqual('SHOW CHANGES FOR TABLE person SINCE 2023-09-07T01:23:52Z LIMIT 10;', show.to_str())
 
     def test_invalid_full_query(self):
-        show = Show(None, "person").since("2023-09-07T01:23:52Z").limit(-1)
+        show = Show(None, "person").since('d"2023-09-07T01:23:52Z"').limit(-1)
         self.assertEqual('SHOW CHANGES FOR TABLE person SINCE d"2023-09-07T01:23:52Z" LIMIT -1;', show.to_str())
         self.assertFalse(show.is_valid())
 
     def test_full_invalid(self):
         show = Show(None, "person").since("2023-09-07").limit(-1)
         self.assertFalse(show.is_valid())
-        self.assertEqual(['Timestamp in the wrong format, you need iso-date like 2024-01-01T10:10:10.000001Z',
+        self.assertEqual(["Timestamp in the wrong format, you need iso-date like d'2024-01-01T10:10:10.000001Z'",
                           "Limit should not be less than 1"], show.validate())
 
 


### PR DESCRIPTION
- add clean_dates function to get dates with prefix out of quotes
- now to_surreal_datetime_str returns datetime with d prefix
- fix datetime bug for fields (prefix d')
- add tests, examples and docs for datetimes
- add test runs for Python 3.13