### PR TITLE
FIX: record_ids fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ with Database("http://127.0.0.1:8000", 'test', 'test', credentials=("user_db", "
         print(result.count()) # just print count of results, but you can do anything here
 ```
 
-## Results##
+## Results ##
 If the method of connection is not raised, it is always returns SurrealResult object on any response of SurrealDB. It was chosen for simplicity.
 
 Please see [examples](https://github.com/kotolex/surrealist/blob/master/examples/result.py)

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,9 +1,16 @@
 ## Release Notes ##
+**Version 1.0.4 (compatible with SurrealDB version 2.0.4):**
+- fix record ids bug (cause SDB since 2.0 not convert string to record_id)
+- create RecordId object to work with string or uid/ulid record_id
+- now all methods can use RecordId, but strings can be used too for compatibility
+- now connection, database and table objects store transport type (http or ws)
+- refactoring
+- add tests, examples and docs for record ids
+
 **Version 1.0.3 (compatible with SurrealDB version 2.0.4):**
 - fix datetime bug for fields (prefix d')
 - add tests, examples and docs for datetimes
 - add test runs for Python 3.13
-
 
 **Version 1.0.2 (compatible with SurrealDB version 2.0.2):**
 - minor fixes

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,7 @@
 - create RecordId object to work with string or uid/ulid record_id
 - now all methods can use RecordId, but strings can be used too for compatibility
 - now connection, database and table objects store transport type (http or ws)
+- redundant DATA_LENGTH_FOR_LOGS was removed
 - refactoring
 - add tests, examples and docs for record ids
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,8 @@
 ## Release Notes ##
 **Version 1.0.4 (compatible with SurrealDB version 2.0.4):**
-- fix record ids bug (cause SDB since 2.0 not convert string to record_id)
+- fix record ids bug (cause SDB since 2.0 not convert string to record_id) 
+- Readme [block for RecordId](https://github.com/kotolex/surrealist#Using_recordid)
+- examples [for RecordId](https://github.com/kotolex/surrealist/blob/master/examples/record_id.py)
 - create RecordId object to work with string or uid/ulid record_id
 - now all methods can use RecordId, but strings can be used too for compatibility
 - now connection, database and table objects store transport type (http or ws)

--- a/examples/live_query.py
+++ b/examples/live_query.py
@@ -5,7 +5,6 @@ from surrealist import Surreal
 
 # Please, read https://github.com/kotolex/surrealist?tab=readme-ov-file#live-query
 
-
 # you need callback, a function which will get dictionary and do something with it
 def call_back(response: dict) -> None:
     print(response)

--- a/examples/record_id.py
+++ b/examples/record_id.py
@@ -1,0 +1,39 @@
+from surrealist import RecordId, get_uuid
+
+# Please read https://github.com/kotolex/surrealist#Using_recordid
+# Refer to https://surrealdb.com/docs/surrealql/datamodel/ids
+
+# You can create a RecordId from id in full form
+record_id = RecordId('person:tobie')
+print(record_id.naive_id)  # person:tobie
+print(record_id.id_part)  # tobie
+print(record_id.table_part)  # person
+print(record_id.to_prefixed_string())  # r'person:tobie'
+print(f"{record_id!r}")  # RecordId('person:tobie')
+# Same RecordId as above we can create with id and table
+record_id = RecordId('tobie', table='person')
+print(record_id.naive_id)  # person:tobie
+print(record_id.id_part)  # tobie
+print(record_id.table_part)  # person
+print(record_id.to_prefixed_string())  # r'person:tobie'
+print(f"{record_id!r}")  # RecordId('person:tobie')
+
+# Note! An exception will be raised if you try to create a RecordId in the wrong way
+# All examples below will raise an exception:
+# record_id = RecordId('tobie') - no table specified
+# record_id = RecordId('tobie', table='person:tobie') - table should not contain ':'
+# record_id = RecordId('person:tobie', table='other') - table names are not equal
+
+# You can generate uuid for your new RecordId
+uid = get_uuid()
+record_id = RecordId(uid, table='book')
+print(record_id.naive_id)  # 76bc591f-5a43-4b4a-bd5b-a52f90cded8a (your uuid will be different)
+# Create record id in valid format for SurrealDB
+print(record_id.to_uid_string())  # book:⟨76bc591f-5a43-4b4a-bd5b-a52f90cded8a⟩
+print(record_id.to_uid_string_with_backticks())  # book:`76bc591f-5a43-4b4a-bd5b-a52f90cded8a`
+
+# And vice versa, you can get parts of record id from book:⟨76bc591f-5a43-4b4a-bd5b-a52f90cded8a⟩
+record_id = RecordId('book:⟨76bc591f-5a43-4b4a-bd5b-a52f90cded8a⟩')
+print(record_id.naive_id)  # book:76bc591f-5a43-4b4a-bd5b-a52f90cded8a
+print(record_id.table_part)  # book
+print(record_id.id_part)  # 76bc591f-5a43-4b4a-bd5b-a52f90cded8a

--- a/examples/result.py
+++ b/examples/result.py
@@ -1,6 +1,6 @@
 from surrealist import SurrealResult
 
-# here we will create Results. but in your work you will get it grom SurrealDB
+# here we will create Results, but in your work you will get it from SurrealDB
 # please see https://github.com/kotolex/surrealist?tab=readme-ov-file#results-and-recordid
 result = SurrealResult(error="Some error")
 print(result.is_error())  # True

--- a/examples/surreal_ql/database.py
+++ b/examples/surreal_ql/database.py
@@ -23,31 +23,6 @@ with Database("http://127.0.0.1:8000", 'test', 'test', credentials=('user_db', '
     # Refer to: https://docs.surrealdb.com/docs/surrealql/statements/return
     print(db.returns("math::abs(-100)"))  # RETURN math::abs(-100);
 
-    # on database object we can DEFINE FIELD
-    # https://surrealdb.com/docs/surrealdb/surrealql/statements/define/field
-    print(db.define_field("new_field", "some_table"))  # DEFINE FIELD new_field ON TABLE some_table;
-    # DEFINE FIELD IF NOT EXISTS new_field ON TABLE some_table;
-    print(db.define_field("new_field", "some_table").if_not_exists())
-    # DEFINE FIELD OVERWRITE new_field ON TABLE some_table;
-    print(db.define_field("new_field", "some_table").overwrite())
-    print(db.define_field("field", "user").type("string"))  # DEFINE FIELD field ON TABLE user TYPE string;
-    # DEFINE FIELD field ON TABLE user FLEXIBLE TYPE bool;
-    print(db.define_field("field", "user").type("bool", is_flexible=True))
-    # DEFINE FIELD locked ON TABLE user TYPE bool DEFAULT false;
-    print(db.define_field("locked", "user").type("bool").default("false"))
-    # DEFINE FIELD locked ON TABLE user TYPE bool DEFAULT false COMMENT "Some comment";
-    print(db.define_field("locked", "user").type("bool").default("false").comment("Some comment"))
-    # DEFINE FIELD updated ON TABLE resource DEFAULT time::now();
-    print(db.define_field("updated", "resource").default("time::now()"))
-    # DEFINE FIELD updated ON TABLE resource DEFAULT time::now() READONLY;
-    print(db.define_field("updated", "resource").default("time::now()").read_only())
-    # DEFINE FIELD email ON TABLE resource TYPE string ASSERT string::is::email($value);
-    print(db.define_field("email", "resource").type("string").asserts("string::is::email($value)"))
-    # DEFINE FIELD comment ON TABLE resource FLEXIBLE TYPE string PERMISSIONS FULL;
-    print(db.define_field("comment", "resource").type("string", is_flexible=True).permissions_full())
-    # DEFINE FIELD comment ON TABLE resource FLEXIBLE TYPE string PERMISSIONS FULL COMMENT "text";
-    print(db.define_field("comment", "resource").type("string", is_flexible=True).permissions_full().comment("text"))
-
     # on database object we can use DEFINE EVENT with sub-query
     # https://surrealdb.com/docs/surrealdb/surrealql/statements/define/event
     # DEFINE EVENT email ON TABLE user WHEN $before.email != $after.email THEN (CREATE event SET user = $value.id,

--- a/examples/surreal_ql/define_field.py
+++ b/examples/surreal_ql/define_field.py
@@ -1,0 +1,27 @@
+from surrealist import Database
+
+with Database("http://127.0.0.1:8000", 'test', 'test', credentials=('user_db', 'user_db')) as db:
+    # on database object we can DEFINE FIELD
+    # https://surrealdb.com/docs/surrealdb/surrealql/statements/define/field
+    print(db.define_field("new_field", "some_table"))  # DEFINE FIELD new_field ON TABLE some_table;
+    # DEFINE FIELD IF NOT EXISTS new_field ON TABLE some_table;
+    print(db.define_field("new_field", "some_table").if_not_exists())
+    # DEFINE FIELD OVERWRITE new_field ON TABLE some_table;
+    print(db.define_field("new_field", "some_table").overwrite())
+    print(db.define_field("field", "user").type("string"))  # DEFINE FIELD field ON TABLE user TYPE string;
+    # DEFINE FIELD field ON TABLE user FLEXIBLE TYPE bool;
+    print(db.define_field("field", "user").type("bool", is_flexible=True))
+    # DEFINE FIELD locked ON TABLE user TYPE bool DEFAULT false;
+    print(db.define_field("locked", "user").type("bool").default("false"))
+    # DEFINE FIELD locked ON TABLE user TYPE bool DEFAULT false COMMENT "Some comment";
+    print(db.define_field("locked", "user").type("bool").default("false").comment("Some comment"))
+    # DEFINE FIELD updated ON TABLE resource DEFAULT time::now();
+    print(db.define_field("updated", "resource").default("time::now()"))
+    # DEFINE FIELD updated ON TABLE resource DEFAULT time::now() READONLY;
+    print(db.define_field("updated", "resource").default("time::now()").read_only())
+    # DEFINE FIELD email ON TABLE resource TYPE string ASSERT string::is::email($value);
+    print(db.define_field("email", "resource").type("string").asserts("string::is::email($value)"))
+    # DEFINE FIELD comment ON TABLE resource FLEXIBLE TYPE string PERMISSIONS FULL;
+    print(db.define_field("comment", "resource").type("string", is_flexible=True).permissions_full())
+    # DEFINE FIELD comment ON TABLE resource FLEXIBLE TYPE string PERMISSIONS FULL COMMENT "text";
+    print(db.define_field("comment", "resource").type("string", is_flexible=True).permissions_full().comment("text"))

--- a/examples/surreal_ql/ql_delete_examples.py
+++ b/examples/surreal_ql/ql_delete_examples.py
@@ -1,4 +1,4 @@
-from surrealist import Database
+from surrealist import Database, RecordId
 
 # Please read https://docs.surrealdb.com/docs/surrealql/statements/delete
 # here we represent analogs for string queries
@@ -8,6 +8,7 @@ from surrealist import Database
 with Database("http://127.0.0.1:8000", 'test', 'test', credentials=("root", "root")) as db:
     print(db.person.delete())  # DELETE person;
     print(db.person.delete("tobie"))  # DELETE person:tobie;
+    print(db.person.delete(RecordId("person:tobie")))  # DELETE person:tobie;
     print(db.table("person").delete("tobie").only())  # DELETE ONLY person:tobie;
 
     # DELETE person WHERE age < 18 RETURN NONE TIMEOUT 10s PARALLEL;

--- a/examples/surreal_ql/ql_insert_examples.py
+++ b/examples/surreal_ql/ql_insert_examples.py
@@ -5,7 +5,7 @@ from surrealist import Database
 
 # Notice: all queries below not executed, just generate representation.
 # To run it against SurrealDB, you need to use run method
-with Database("http://127.0.0.1:8000", 'test', 'test', credentials=("root", "root")) as db:
+with Database("http://127.0.0.1:8000", 'test', 'test', credentials=("user_db", "user_db")) as db:
     data = {
         'name': 'SurrealDB',
         'founded': "2021-09-10",

--- a/examples/surreal_ql/ql_select_examples.py
+++ b/examples/surreal_ql/ql_select_examples.py
@@ -1,14 +1,15 @@
-from surrealist import Database
+from surrealist import Database, RecordId
 
 # Please read https://docs.surrealdb.com/docs/surrealql/statements/select
 # here we represent analogs for string queries
 
 # Notice: all queries below not executed, just generate representation.
 # To run it against SurrealDB, you need to use run method
-with Database("http://127.0.0.1:8000", 'test', 'test', credentials=("root", "root")) as db:
+with Database("http://127.0.0.1:8000", 'test', 'test', credentials=("user_db", "user_db")) as db:
     print(db.table("person").select())  # SELECT * FROM person;
     print(db.table("person").select("*"))  # SELECT * FROM person;
     print(db.table("person").select().by_id("john"))  # SELECT * FROM person:john;
+    print(db.table("person").select().by_id(RecordId("person:john")))  # SELECT * FROM person:john;
     print(db.table("person").select("name", "age"))  # SELECT name, age FROM person;
     print(db.table("person").select("name", "age").by_id("john").only())  # SELECT name, age FROM ONLY person:john;
     print(db.table("person").select(value="age").by_id("john"))  # SELECT VALUE age FROM person:john;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "surrealist"
-version = "1.0.3"
+version = "1.0.4"
 description = "Python client for SurrealDB, latest SurrealDB version compatible, all features supported"
 readme = "README.md"
 authors = [{ name = "kotolex", email = "farofwell@gmail.com" }]

--- a/src/surrealist/__init__.py
+++ b/src/surrealist/__init__.py
@@ -5,10 +5,10 @@ from .ql import Database, DatabaseConnectionsPool, Table, Where
 from .record_id import RecordId
 from .result import SurrealResult
 from .surreal import Surreal
-from .utils import DATA_LENGTH_FOR_LOGS, get_uuid, to_surreal_datetime_str, to_datetime, LOG_FORMAT
+from .utils import get_uuid, to_surreal_datetime_str, to_datetime, LOG_FORMAT
 
 __all__ = ("Surreal", "SurrealResult", "WebSocketConnection", "HttpConnection", "PySurrealError", "HttpConnectionError",
            "HttpClientError", "SurrealConnectionError", "WebSocketConnectionError", "WebSocketConnectionClosedError",
            "ConnectionParametersError", "CompatibilityError", "OperationOnClosedConnectionError", "WrongCallError",
-           "DATA_LENGTH_FOR_LOGS", "Connection", "get_uuid", "Database", "Table", "Where", "DatabaseConnectionsPool",
+           "Connection", "get_uuid", "Database", "Table", "Where", "DatabaseConnectionsPool",
            "to_surreal_datetime_str", "to_datetime", "LOG_FORMAT", "Algorithm", "RecordId", "SurrealRecordIdError")

--- a/src/surrealist/__init__.py
+++ b/src/surrealist/__init__.py
@@ -2,6 +2,7 @@ from .connections import WebSocketConnection, HttpConnection, Connection
 from .enums import Algorithm
 from .errors import *
 from .ql import Database, DatabaseConnectionsPool, Table, Where
+from .record_id import RecordId
 from .result import SurrealResult
 from .surreal import Surreal
 from .utils import DATA_LENGTH_FOR_LOGS, get_uuid, to_surreal_datetime_str, to_datetime, LOG_FORMAT
@@ -10,4 +11,4 @@ __all__ = ("Surreal", "SurrealResult", "WebSocketConnection", "HttpConnection", 
            "HttpClientError", "SurrealConnectionError", "WebSocketConnectionError", "WebSocketConnectionClosedError",
            "ConnectionParametersError", "CompatibilityError", "OperationOnClosedConnectionError", "WrongCallError",
            "DATA_LENGTH_FOR_LOGS", "Connection", "get_uuid", "Database", "Table", "Where", "DatabaseConnectionsPool",
-           "to_surreal_datetime_str", "to_datetime", "LOG_FORMAT", "Algorithm")
+           "to_surreal_datetime_str", "to_datetime", "LOG_FORMAT", "Algorithm", "RecordId", "SurrealRecordIdError")

--- a/src/surrealist/clients/http_client.py
+++ b/src/surrealist/clients/http_client.py
@@ -7,7 +7,7 @@ from typing import Optional, Tuple, Dict, Union, BinaryIO
 from urllib.error import URLError, HTTPError
 
 from surrealist.errors import HttpClientError, TooManyNestedLevelsError
-from surrealist.utils import ENCODING, DEFAULT_TIMEOUT, crop_data, mask_pass, NS, DB, AC
+from surrealist.utils import ENCODING, DEFAULT_TIMEOUT, mask_pass, NS, DB, AC
 
 logger = getLogger("surrealist.clients.http")
 
@@ -138,6 +138,6 @@ def mask_opts(options: Dict) -> Dict:
         if key == "headers" and "Authorization" in value:
             value = {**value, "Authorization": "Bearer ******"}
         elif key == "data":
-            value = crop_data(mask_pass(str(value)))
+            value = mask_pass(str(value))
         masked_opts[key] = value
     return masked_opts

--- a/src/surrealist/clients/ws_client.py
+++ b/src/surrealist/clients/ws_client.py
@@ -10,7 +10,7 @@ import websocket
 
 from surrealist.errors import WebSocketConnectionClosedError, TooManyNestedLevelsError
 from surrealist.result import to_result, SurrealResult
-from surrealist.utils import DEFAULT_TIMEOUT, get_uuid, crop_data, mask_pass
+from surrealist.utils import DEFAULT_TIMEOUT, get_uuid, mask_pass
 
 logger = getLogger("surrealist.clients.websocket")
 
@@ -42,12 +42,12 @@ class WebSocketClient:
         :param _ws: connection object
         :param message: string message
         """
-        logger.debug("Get message %s", crop_data(message))
+        logger.debug("Get message %s", message)
         try:
             mess = json.loads(message)
         except JSONDecodeError as je:
             # Should never happen, all messages via json
-            logger.error("Got non-json response %s", crop_data(message), exc_info=True)
+            logger.error("Got non-json response %s", message, exc_info=True)
             raise ValueError(f"Got non-json response! {message}") from je
         except RecursionError as e:
             logger.error("Cant deserialize object, too many nested levels")
@@ -124,7 +124,7 @@ class WebSocketClient:
         except RecursionError as e:
             logger.error("Cant serialize object, too many nested levels")
             raise TooManyNestedLevelsError("Cant serialize object, too many nested levels") from e
-        logger.debug("Send data: %s", crop_data(mask_pass(data_string)))
+        logger.debug("Send data: %s", mask_pass(data_string))
         self._messages[id_] = Queue(maxsize=1)
         self._ws.send(data_string)
         res = self._get_by_id(id_)

--- a/src/surrealist/connections/connection.py
+++ b/src/surrealist/connections/connection.py
@@ -7,7 +7,7 @@ from surrealist.enums import Transport
 from surrealist.errors import OperationOnClosedConnectionError, WrongParameterError
 from surrealist.record_id import RecordId
 from surrealist.result import SurrealResult
-from surrealist.utils import (DEFAULT_TIMEOUT, crop_data, NS, DB, AC, mask_pass, clean_dates, StrOrRecord,
+from surrealist.utils import (DEFAULT_TIMEOUT, NS, DB, AC, mask_pass, clean_dates, StrOrRecord,
                               get_table_or_record_id)
 
 logger = getLogger("surrealist.connection")
@@ -89,7 +89,7 @@ class Connection(ABC):
         :param table_name: name of the table
         :return: result containing count, like SurrealResult(id='', error=None, result=[{'count': 1}], time='123.333µs')
         """
-        logger.info("Query-Operation: COUNT. Table: %s", crop_data(table_name))
+        logger.info("Query-Operation: COUNT. Table: %s", table_name)
         result = self.query(f"SELECT count() FROM {table_name} GROUP ALL;")
         if not result.is_error():
             result.result = self._get_count(result.result)
@@ -284,7 +284,7 @@ class Connection(ABC):
         if access is not None:
             params[AC] = access
         data = {"method": "signin", "params": [params]}
-        logger.info("Operation: SIGNIN. Data: %s", crop_data(mask_pass(str(params))))
+        logger.info("Operation: SIGNIN. Data: %s", mask_pass(str(params)))
         return self._use_rpc(data)
 
     @abstractmethod
@@ -318,7 +318,7 @@ class Connection(ABC):
         :return: result of request
         """
         data = {"method": "let", "params": [name, value]}
-        logger.info("Operation: LET. Name: %s, Value: %s", crop_data(name), crop_data(str(value)))
+        logger.info("Operation: LET. Name: %s, Value: %s", name, value)
         return self._use_rpc(data)
 
     @connected
@@ -333,7 +333,7 @@ class Connection(ABC):
         :return: result of request
         """
         data = {"method": "unset", "params": [name]}
-        logger.info("Operation: UNSET. Variable name: %s", crop_data(name))
+        logger.info("Operation: UNSET. Variable name: %s", name)
         return self._use_rpc(data)
 
     @abstractmethod
@@ -398,7 +398,7 @@ class Connection(ABC):
             raise WrongParameterError("Query parameter should be a dictionary with 3 fields\n"
                                       "Please see https://surrealdb.com/docs/surrealdb/integration/rpc#graphql")
         data = {"method": "graphql", "params": [query, {"pretty": pretty}]}
-        logger.info("Operation: GRAPHQL. Query: %s, pretty: %s", crop_data(str(query)), pretty)
+        logger.info("Operation: GRAPHQL. Query: %s, pretty: %s", query, pretty)
         result = self._use_rpc(data)
         return result
 
@@ -427,7 +427,7 @@ class Connection(ABC):
             if len(data["params"]) == 1:
                 data["params"].append(None)
             data["params"].append(args)
-        logger.info("Operation: RUN. Function: %s, version: %s, args: %s", crop_data(func_name), version, args)
+        logger.info("Operation: RUN. Function: %s, version: %s, args: %s", func_name, version, args)
         result = self._use_rpc(data)
         return result
 
@@ -471,7 +471,7 @@ class Connection(ABC):
         """
         table_name = get_table_or_record_id(table_name, record_id)
         data = {"method": "select", "params": [table_name]}
-        logger.info("Operation: SELECT. Table: %s", crop_data(table_name))
+        logger.info("Operation: SELECT. Table: %s", table_name)
         result = self._use_rpc(data)
         if not isinstance(result.result, List) and not result.is_error():
             result.result = [result.result] if result.result else []
@@ -506,7 +506,7 @@ class Connection(ABC):
                 record_id = RecordId(record_id, table=table_name)
             data["id"] = record_id.to_valid_string()
         _data = {"method": "create", "params": [table_name, data]}
-        logger.info("Operation: CREATE. Table: %s, data: %s", crop_data(table_name), crop_data(str(data)))
+        logger.info("Operation: CREATE. Table: %s, data: %s", table_name, data)
         result = self._use_rpc(_data)
         if isinstance(result.result, List) and len(result.result) == 1:
             result.result = result.result[0]
@@ -541,7 +541,7 @@ class Connection(ABC):
         """
         table_name = get_table_or_record_id(table_name, record_id)
         _data = {"method": "update", "params": [table_name, data]}
-        logger.info("Operation: UPDATE. Table: %s, data: %s", crop_data(table_name), crop_data(str(data)))
+        logger.info("Operation: UPDATE. Table: %s, data: %s", table_name, data)
         return self._use_rpc(_data)
 
     @connected
@@ -571,7 +571,7 @@ class Connection(ABC):
         """
         table_name = get_table_or_record_id(table_name, record_id)
         _data = {"method": "upsert", "params": [table_name, data]}
-        logger.info("Operation: UPSERT. Table: %s, data: %s", crop_data(table_name), crop_data(str(data)))
+        logger.info("Operation: UPSERT. Table: %s, data: %s", table_name, data)
         return self._use_rpc(_data)
 
     @connected
@@ -596,7 +596,7 @@ class Connection(ABC):
         :return: result of request
         """
         _data = {"method": "insert", "params": [table_name, data]}
-        logger.info("Operation: INSERT. Table: %s, data: %s", crop_data(table_name), crop_data(str(data)))
+        logger.info("Operation: INSERT. Table: %s, data: %s", table_name, data)
         return self._use_rpc(_data)
 
     @connected
@@ -620,7 +620,7 @@ class Connection(ABC):
         :return: result of request
         """
         data = {"method": "insert_relation", "params": [table_name, data]}
-        logger.info("Operation: INSERT-RELATION. Table: %s, data: %s", crop_data(str(table_name)), crop_data(str(data)))
+        logger.info("Operation: INSERT-RELATION. Table: %s, data: %s", table_name, data)
         result = self._use_rpc(data)
         return result
 
@@ -645,7 +645,7 @@ class Connection(ABC):
         """
         table_name = get_table_or_record_id(table_name, record_id)
         _data = {"method": "merge", "params": [table_name, data]}
-        logger.info("Operation: MERGE. Table: %s, data: %s", crop_data(table_name), crop_data(str(data)))
+        logger.info("Operation: MERGE. Table: %s, data: %s", table_name, data)
         return self._use_rpc(_data)
 
     @connected
@@ -670,7 +670,7 @@ class Connection(ABC):
         """
         table_name = get_table_or_record_id(table_name, record_id)
         _data = {"method": "delete", "params": [table_name]}
-        logger.info("Operation: DELETE. Table: %s", crop_data(table_name))
+        logger.info("Operation: DELETE. Table: %s", table_name)
         return self._use_rpc(_data)
 
     @connected
@@ -704,8 +704,7 @@ class Connection(ABC):
         if return_diff:
             params.append(return_diff)
         _data = {"method": "patch", "params": params}
-        logger.info("Operation: PATCH. Table: %s, data: %s, use DIFF: %s", crop_data(table_name), crop_data(str(data)),
-                    return_diff)
+        logger.info("Operation: PATCH. Table: %s, data: %s, use DIFF: %s", table_name, data, return_diff)
         return self._use_rpc(_data)
 
     @connected
@@ -731,7 +730,7 @@ class Connection(ABC):
         if variables is not None:
             params.append(variables)
         data = {"method": "query", "params": params}
-        logger.info("Operation: QUERY. Query: %s, variables: %s", crop_data(query), crop_data(str(variables)))
+        logger.info("Operation: QUERY. Query: %s, variables: %s", query, variables)
         result = self._use_rpc(data)
         result.query = params[0] if len(params) == 1 else params
         return result
@@ -757,7 +756,7 @@ class Connection(ABC):
         if data is not None:
             full_data["params"].append(data)
         logger.info("Operation: RELATE. Relate_to: %s, relation_table: %s, relate_from: %s, data: %s", relate_to,
-                    relation_table, relate_from, crop_data(str(data)))
+                    relation_table, relate_from, data)
         result = self._use_rpc(full_data)
         return result
 

--- a/src/surrealist/connections/connection.py
+++ b/src/surrealist/connections/connection.py
@@ -1,12 +1,14 @@
-import json
 from abc import ABC, abstractmethod
 from functools import wraps
 from logging import getLogger
 from typing import Tuple, Dict, Optional, Union, List, Callable, Any
 
-from surrealist.errors import OperationOnClosedConnectionError, TooManyNestedLevelsError, WrongParameterError
+from surrealist.enums import Transport
+from surrealist.errors import OperationOnClosedConnectionError, WrongParameterError
+from surrealist.record_id import RecordId
 from surrealist.result import SurrealResult
-from surrealist.utils import DEFAULT_TIMEOUT, crop_data, NS, DB, AC, mask_pass, clean_dates
+from surrealist.utils import (DEFAULT_TIMEOUT, crop_data, NS, DB, AC, mask_pass, clean_dates, StrOrRecord,
+                              get_table_or_record_id)
 
 logger = getLogger("surrealist.connection")
 LINK = "https://github.com/kotolex/surrealist?tab=readme-ov-file#recursion-and-json-in-python"
@@ -72,13 +74,6 @@ class Connection(ABC):
         """
         return self._connected
 
-    def _in_out_json(self, data, is_loads: bool):
-        try:
-            return json.loads(data) if is_loads else json.dumps(data)
-        except RecursionError as e:
-            logger.error("Cant serialize/deserialize object, too many nested levels")
-            raise TooManyNestedLevelsError(f"Cant serialize object, too many nested levels\nRefer to: {LINK}") from e
-
     @connected
     def count(self, table_name: str) -> SurrealResult:
         """
@@ -124,7 +119,7 @@ class Connection(ABC):
 
         Refer to: https://docs.surrealdb.com/docs/surrealql/statements/info
 
-        :param structured: if True returns data in structured view (use STRUCTURE statement). Note: experimental!
+        :param structured: if True, return data in structured view (use STRUCTURE statement). Note: experimental!
         :return: full database information
         """
         return self._info("DB", structured)
@@ -138,7 +133,7 @@ class Connection(ABC):
 
         Refer to: https://docs.surrealdb.com/docs/surrealql/statements/info
 
-        :param structured: if True returns data in structured view (use STRUCTURE statement). Note: experimental!
+        :param structured: if True, return data in structured view (use STRUCTURE statement). Note: experimental!
         :return: full namespace information
         """
         return self._info("NS", structured)
@@ -152,7 +147,7 @@ class Connection(ABC):
 
         Refer to: https://docs.surrealdb.com/docs/surrealql/statements/info
 
-        :param structured: if True returns data in structured view (use STRUCTURE statement). Note: experimental!
+        :param structured: if True, return data in structured view (use STRUCTURE statement). Note: experimental!
         :return: information about root
         """
         return self._info("ROOT", structured)
@@ -298,6 +293,14 @@ class Connection(ABC):
         This method specifies the namespace and optionally database for the current connection
 
         Refer to: https://docs.surrealdb.com/docs/surrealql/statements/use
+        """
+
+    @abstractmethod
+    def transport(self) -> Transport:
+        """
+        This method returns the current transport
+
+        Refer to: https://github.com/kotolex/surrealist?tab=readme-ov-file#transports
         """
 
     @connected
@@ -446,7 +449,7 @@ class Connection(ABC):
         return result
 
     @connected
-    def select(self, table_name: str, record_id: Optional[str] = None) -> SurrealResult:
+    def select(self, table_name: str, record_id: Optional[StrOrRecord] = None) -> SurrealResult:
         """
         This method selects either all records in a table or a single record
 
@@ -458,6 +461,7 @@ class Connection(ABC):
         connection.select("article") # select all records in article table
         connection.select("article:first") # select one article with id 'first'
         connection.select("article", "first") # select one article with id 'first', analog of previous
+        connection.select("article", RecordId("first", "article")) # analog of previous
 
         Notice: do not specify id twice: in table name and in record_id, it will cause error on SurrealDB side
 
@@ -465,7 +469,7 @@ class Connection(ABC):
         :param record_id: optional parameter, if it exists it will transform table_name to "table_name:record_id"
         :return: result of request
         """
-        table_name = table_name if record_id is None else f"{table_name}:{record_id}"
+        table_name = get_table_or_record_id(table_name, record_id)
         data = {"method": "select", "params": [table_name]}
         logger.info("Operation: SELECT. Table: %s", crop_data(table_name))
         result = self._use_rpc(data)
@@ -474,7 +478,7 @@ class Connection(ABC):
         return result
 
     @connected
-    def create(self, table_name: str, data: Dict, record_id: Optional[str] = None) -> SurrealResult:
+    def create(self, table_name: str, data: Dict, record_id: Optional[StrOrRecord] = None) -> SurrealResult:
         """
         This method creates a record either with a random or specified record_id. If no id specified in record_id or
         in data arguments, then id will be generated by SurrealDB
@@ -494,11 +498,13 @@ class Connection(ABC):
 
         :param table_name: table name or table name with record_id to create
         :param data: dict with data to create
-        :param record_id: optional parameter, if it exists it will transform table_name to "table_name:record_id"
+        :param record_id: optional parameter, it can be string or record_id object
         :return: result of request
         """
         if record_id is not None:
-            data["id"] = record_id
+            if isinstance(record_id, str):
+                record_id = RecordId(record_id, table=table_name)
+            data["id"] = record_id.to_valid_string()
         _data = {"method": "create", "params": [table_name, data]}
         logger.info("Operation: CREATE. Table: %s, data: %s", crop_data(table_name), crop_data(str(data)))
         result = self._use_rpc(_data)
@@ -507,7 +513,7 @@ class Connection(ABC):
         return result
 
     @connected
-    def update(self, table_name: str, data: Dict, record_id: Optional[str] = None) -> SurrealResult:
+    def update(self, table_name: str, data: Dict, record_id: Optional[StrOrRecord] = None) -> SurrealResult:
         """
         This method can be used to update or modify records in the database. So all old fields will be deleted, and new
         will be added, if you wand just to add field to record, keeping old ones -use **merge** method instead.
@@ -533,13 +539,13 @@ class Connection(ABC):
         :param record_id: optional parameter, if it exists it will transform table_name to "table_name:record_id"
         :return: result of request
         """
-        table_name = table_name if record_id is None else f"{table_name}:{record_id}"
+        table_name = get_table_or_record_id(table_name, record_id)
         _data = {"method": "update", "params": [table_name, data]}
         logger.info("Operation: UPDATE. Table: %s, data: %s", crop_data(table_name), crop_data(str(data)))
         return self._use_rpc(_data)
 
     @connected
-    def upsert(self, table_name: str, data: Dict, record_id: Optional[str] = None) -> SurrealResult:
+    def upsert(self, table_name: str, data: Dict, record_id: Optional[StrOrRecord] = None) -> SurrealResult:
         """
         This method can be used to create or update records in the database. So all old fields will be deleted, and new
         will be added, if you wand just to add field to record, keeping old ones -use **merge** method instead.
@@ -563,7 +569,7 @@ class Connection(ABC):
         :param record_id: optional parameter, if it exists it will transform table_name to "table_name:record_id"
         :return: result of request
         """
-        table_name = table_name if record_id is None else f"{table_name}:{record_id}"
+        table_name = get_table_or_record_id(table_name, record_id)
         _data = {"method": "upsert", "params": [table_name, data]}
         logger.info("Operation: UPSERT. Table: %s, data: %s", crop_data(table_name), crop_data(str(data)))
         return self._use_rpc(_data)
@@ -619,7 +625,7 @@ class Connection(ABC):
         return result
 
     @connected
-    def merge(self, table_name: str, data: Dict, record_id: Optional[str] = None) -> SurrealResult:
+    def merge(self, table_name: str, data: Dict, record_id: Optional[StrOrRecord] = None) -> SurrealResult:
         """
         This method merges specified data into either all records in a table or a single record. Old data in records
         will not be deleted, if you want to replace old data with new - use **update** method.If
@@ -637,13 +643,13 @@ class Connection(ABC):
         :param record_id: optional parameter, if it exists it will transform table_name to "table_name:record_id"
         :return: result of request
         """
-        table_name = table_name if record_id is None else f"{table_name}:{record_id}"
+        table_name = get_table_or_record_id(table_name, record_id)
         _data = {"method": "merge", "params": [table_name, data]}
         logger.info("Operation: MERGE. Table: %s, data: %s", crop_data(table_name), crop_data(str(data)))
         return self._use_rpc(_data)
 
     @connected
-    def delete(self, table_name: str, record_id: Optional[str] = None) -> SurrealResult:
+    def delete(self, table_name: str, record_id: Optional[StrOrRecord] = None) -> SurrealResult:
         """
         This method deletes all records in a table or a single record, be careful and don't forget to specify id if you
         do not want to delete all records. This method does not remove table itself, only records in it.As a result of
@@ -662,13 +668,13 @@ class Connection(ABC):
         :param record_id: optional parameter, if it exists it will transform table_name to "table_name:record_id"
         :return: result of request
         """
-        table_name = table_name if record_id is None else f"{table_name}:{record_id}"
+        table_name = get_table_or_record_id(table_name, record_id)
         _data = {"method": "delete", "params": [table_name]}
         logger.info("Operation: DELETE. Table: %s", crop_data(table_name))
         return self._use_rpc(_data)
 
     @connected
-    def patch(self, table_name: str, data: Union[Dict, List], record_id: Optional[str] = None,
+    def patch(self, table_name: str, data: Union[Dict, List], record_id: Optional[StrOrRecord] = None,
               return_diff: bool = False) -> SurrealResult:
         """
         This method changes specified data in one ar all records. If given table does not exist, new table and record
@@ -693,7 +699,7 @@ class Connection(ABC):
         :param return_diff: True if you want to get only DIFF info, False for a standard results
         :return: result of request
         """
-        table_name = table_name if record_id is None else f"{table_name}:{record_id}"
+        table_name = get_table_or_record_id(table_name, record_id)
         params = [table_name, data]
         if return_diff:
             params.append(return_diff)

--- a/src/surrealist/connections/http_connection.py
+++ b/src/surrealist/connections/http_connection.py
@@ -7,7 +7,7 @@ from surrealist.connections.connection import Connection, connected
 from surrealist.enums import Transport
 from surrealist.errors import (CompatibilityError, HttpConnectionError, HttpClientError, SurrealConnectionError)
 from surrealist.result import SurrealResult, to_result
-from surrealist.utils import (ENCODING, DEFAULT_TIMEOUT, crop_data, HTTP_OK, NS, DB, AC)
+from surrealist.utils import (ENCODING, DEFAULT_TIMEOUT, HTTP_OK, NS, DB, AC)
 
 logger = getLogger("surrealist.connections.http")
 
@@ -79,7 +79,7 @@ class HttpConnection(Connection):
         :return: result of request
         """
         with open(path, 'rb') as file:
-            logger.info("Operation: IMPORT. Path: %s", crop_data(str(path)))
+            logger.info("Operation: IMPORT. Path: %s", path)
             _, text = self._simple_request("POST", "import", file, type_of_content="FILE")
         return to_result(text)
 
@@ -111,7 +111,7 @@ class HttpConnection(Connection):
         :return: result of request
         """
         with open(path, 'rb') as file:
-            logger.info("Operation: ML IMPORT. Path: %s", crop_data(str(path)))
+            logger.info("Operation: ML IMPORT. Path: %s", path)
             _, text = self._simple_request("POST", "ml/import", file.read().decode(ENCODING), type_of_content="STR")
         return to_result(text)
 
@@ -150,7 +150,7 @@ class HttpConnection(Connection):
         :param database: name of the database to use (optional)
         :return: None
         """
-        logger.info("Operation: USE. Namespace: %s, database %s", crop_data(namespace), crop_data(database or "None"))
+        logger.info("Operation: USE. Namespace: %s, database %s", namespace, database or "None")
         self._db_params = {NS: namespace}
         if database:
             self._db_params[DB] = database
@@ -209,7 +209,7 @@ class HttpConnection(Connection):
     def _simple_get(self, endpoint: str) -> Tuple[int, str]:
         with self._http_client.get(endpoint) as resp:
             status, text = resp.status, resp.read().decode(ENCODING)
-            _body = "is empty" if not text else crop_data(text)
+            _body = "is empty" if not text else text
             logger.info("Response from /%s, status_code: %s, body: %s", endpoint, status, _body)
             return status, text
 
@@ -222,7 +222,7 @@ class HttpConnection(Connection):
             status, text = resp.status, resp.read().decode(ENCODING)
             if type_of_content == "FILE":
                 data.close()
-            _body = "is empty" if not text else crop_data(text)
+            _body = "is empty" if not text else text
             logger.info("Response from /%s, status_code: %s, body %s", endpoint, status, _body)
         return status, text
 

--- a/src/surrealist/connections/http_connection.py
+++ b/src/surrealist/connections/http_connection.py
@@ -4,6 +4,7 @@ from typing import Tuple, Dict, Optional, Union, Any, BinaryIO
 
 from surrealist.clients.http_client import HttpClient
 from surrealist.connections.connection import Connection, connected
+from surrealist.enums import Transport
 from surrealist.errors import (CompatibilityError, HttpConnectionError, HttpClientError, SurrealConnectionError)
 from surrealist.result import SurrealResult, to_result
 from surrealist.utils import (ENCODING, DEFAULT_TIMEOUT, crop_data, HTTP_OK, NS, DB, AC)
@@ -60,6 +61,9 @@ class HttpConnection(Connection):
             raise SurrealConnectionError(f"Cant connect to {url}\n"
                                          f"Is your SurrealDB started and work on that url? "
                                          f"Refer to https://docs.surrealdb.com/docs/introduction/start")
+
+    def transport(self) -> Transport:
+        return Transport.HTTP
 
     @connected
     def import_data(self, path: Union[str, Path]) -> SurrealResult:

--- a/src/surrealist/connections/pool.py
+++ b/src/surrealist/connections/pool.py
@@ -6,6 +6,7 @@ from threading import Thread
 from typing import Optional, Tuple, Dict, Callable, Any
 
 from surrealist.connections.connection import Connection
+from surrealist.enums import Transport
 from surrealist.errors import OperationOnClosedConnectionError
 from surrealist.result import SurrealResult
 from surrealist.surreal import Surreal
@@ -20,6 +21,7 @@ def connected_and_pooled(func):
     Wrapper to check if pool is connected ad delegate work to underlying connections
     :param func: function to wrap
     """
+
     @wraps(func)
     def wrapped(*args, **kwargs):
         # args[0] is a self-argument in methods
@@ -35,12 +37,13 @@ def connected_and_pooled(func):
 class Pool:
     """
     Represents a pool of connections, which is creating a bunch of database connections on start and delegating all
-    tasks to the first non-busy connection. So, if there are no nore connections in the pool, it tries to create a new
+    tasks to the first non-busy connection. So, if there are no more connections in the pool, it tries to create a new
     one if the maximum is not exceeded. If the maximum of connections is reached and no more connections to work with -
     client will be blocked until the first connection finishes the task and appears at the pool.
     """
+
     def __init__(self, first_connection: Connection, url: str, namespace: Optional[str] = None,
-                 database: Optional[str] = None, access: Optional[str] =None, credentials: Tuple[str, str] = None,
+                 database: Optional[str] = None, access: Optional[str] = None, credentials: Tuple[str, str] = None,
                  use_http: bool = False, timeout: int = DEFAULT_TIMEOUT, min_connections: int = CORES_COUNT,
                  max_connections: int = 50):
         self._options = {
@@ -56,6 +59,9 @@ class Pool:
         self._counter = 1
         self._connected = True
         self._start()
+
+    def transport(self) -> Transport:
+        return Transport.HTTP if self._options["use_http"] else Transport.WEBSOCKET
 
     @property
     def connections_count(self) -> int:

--- a/src/surrealist/connections/ws_connection.py
+++ b/src/surrealist/connections/ws_connection.py
@@ -9,7 +9,7 @@ from surrealist.enums import Transport
 from surrealist.errors import (SurrealConnectionError, WebSocketConnectionError, WebSocketConnectionClosedError,
                                CompatibilityError)
 from surrealist.result import SurrealResult
-from surrealist.utils import DEFAULT_TIMEOUT, crop_data, NS, DB, AC
+from surrealist.utils import DEFAULT_TIMEOUT, NS, DB, AC
 
 logger = getLogger("surrealist.connections.websocket")
 
@@ -122,7 +122,7 @@ class WebSocketConnection(Connection):
             raise CompatibilityError(msg)
         params = [namespace, database]
         data = {"method": "use", "params": params}
-        logger.info("Operation: USE. Namespace: %s, database %s", crop_data(namespace), crop_data(database or "None"))
+        logger.info("Operation: USE. Namespace: %s, database %s", namespace, database or "None")
         result = self._run(data)
         if not result.is_error():
             # if USE was OK we need to store new data (ns and db)
@@ -155,7 +155,7 @@ class WebSocketConnection(Connection):
         if return_diff:
             params.append(True)
         data = {"method": "live", "params": params}
-        logger.info("Operation: LIVE. Data: %s", crop_data(str(params)))
+        logger.info("Operation: LIVE. Data: %s", params)
         return self._run(data, callback)
 
     @connected
@@ -180,7 +180,7 @@ class WebSocketConnection(Connection):
         :return: result of request with the live_id in 'result' field
         """
         data = {"method": "query", "params": [custom_query], "additional": "live"}
-        logger.info("Operation: CUSTOM LIVE. Query: %s", crop_data(custom_query))
+        logger.info("Operation: CUSTOM LIVE. Query: %s", custom_query)
         result = self._run(data, callback)
         result.query = custom_query
         return result
@@ -198,7 +198,7 @@ class WebSocketConnection(Connection):
         :return: result of request
         """
         data = {"method": "kill", "params": [live_query_id]}
-        logger.info("Operation: KILL. Live_id: %s", crop_data(live_query_id))
+        logger.info("Operation: KILL. Live_id: %s", live_query_id)
         return self._run(data)
 
     def export(self):
@@ -267,5 +267,5 @@ class WebSocketConnection(Connection):
 
     def _run(self, data, callback: Callable = None) -> SurrealResult:
         result = self._client.send(data, callback)
-        logger.info("Got result: %s", crop_data(str(result)))
+        logger.info("Got result: %s", result)
         return result

--- a/src/surrealist/connections/ws_connection.py
+++ b/src/surrealist/connections/ws_connection.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple, Dict, Union, Callable, Any
 
 from surrealist.clients.ws_client import WebSocketClient
 from surrealist.connections.connection import Connection, connected
+from surrealist.enums import Transport
 from surrealist.errors import (SurrealConnectionError, WebSocketConnectionError, WebSocketConnectionClosedError,
                                CompatibilityError)
 from surrealist.result import SurrealResult
@@ -93,6 +94,9 @@ class WebSocketConnection(Connection):
                     logger.error("Error on connecting to %s. Info %s", self._base_url, signin_result)
                     raise WebSocketConnectionError(f"Error on connecting to '{self._base_url}'.\nInfo: {signin_result}")
                 self._token = signin_result.result
+
+    def transport(self) -> Transport:
+        return Transport.WEBSOCKET
 
     @connected
     def use(self, namespace: str, database: Optional[str] = None) -> SurrealResult:

--- a/src/surrealist/enums.py
+++ b/src/surrealist/enums.py
@@ -1,10 +1,18 @@
 from enum import Enum, auto
 
 
+class Transport(Enum):
+    """
+    Represents different types of transport for connection
+    """
+    HTTP = "http"
+    WEBSOCKET = "websocket"
+
+
 class Algorithm(Enum):
     """
     Represents different types of cryptographic algorithms to use for token verification
-    https://github.com/surrealdb/surrealdb/blob/main/core/src/iam/verify.rs#L17-L72
+    Refer to: https://github.com/surrealdb/surrealdb/blob/main/core/src/iam/verify.rs#L17-L72
     """
     HS256 = auto()
     HS384 = auto()

--- a/src/surrealist/errors.py
+++ b/src/surrealist/errors.py
@@ -15,6 +15,12 @@ class WrongParameterError(PySurrealError):
     """
 
 
+class SurrealRecordIdError(PySurrealError):
+    """
+    Raises when the wrong id or table is passed for RecordId
+    """
+
+
 class SurrealConnectionError(PySurrealError):
     """
     Raises on any problem with connection to SurrealDB, check url and other parameters

--- a/src/surrealist/ql/database.py
+++ b/src/surrealist/ql/database.py
@@ -520,7 +520,7 @@ class Database:
 
         Refer to: https://docs.surrealdb.com/docs/surrealql/statements/define/field
 
-        Example: https://github.com/kotolex/surrealist/blob/master/examples/surreal_ql/database.py
+        Example: https://github.com/kotolex/surrealist/blob/master/examples/surreal_ql/define_field.py
 
         :param field_name: name of the field
         :param table_name: name of the table
@@ -581,4 +581,5 @@ class Database:
         return self._connection.run(function_name, version=version, args=args)
 
     def __repr__(self):
-        return f"Database(namespace={self._namespace}, name={self._database}, connected={self.is_connected()})"
+        return f"Database(namespace={self._namespace}, name={self._database}, connected={self.is_connected()}, " \
+               f"connection with {self._connection.transport().value} transport)"

--- a/src/surrealist/ql/statements/create.py
+++ b/src/surrealist/ql/statements/create.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from surrealist.connections import Connection
 from surrealist.ql.statements.create_statements import CreateUseSetContent
 from surrealist.ql.statements.statement import Statement
-from surrealist.utils import OK
+from surrealist.utils import OK, StrOrRecord, get_table_or_record_id
 
 
 class Create(Statement, CreateUseSetContent):
@@ -23,7 +23,7 @@ class Create(Statement, CreateUseSetContent):
     [ PARALLEL ];
     """
 
-    def __init__(self, connection: Connection, table_name: str, record_id: Optional[str] = None):
+    def __init__(self, connection: Connection, table_name: str, record_id: Optional[StrOrRecord] = None):
         """
         Init for Create
         :param connection: connection relied on
@@ -34,6 +34,7 @@ class Create(Statement, CreateUseSetContent):
         self._table_name = table_name
         self._only = False
         self._record_id = record_id
+        self._name = get_table_or_record_id(self._table_name, record_id)
 
     def only(self) -> "Create":
         """
@@ -47,5 +48,4 @@ class Create(Statement, CreateUseSetContent):
 
     def _clean_str(self):
         only = "" if not self._only else " ONLY"
-        name = self._table_name if not self._record_id else f"{self._table_name}:{self._record_id}"
-        return f"CREATE{only} {name}"
+        return f"CREATE{only} {self._name}"

--- a/src/surrealist/ql/statements/create_statements.py
+++ b/src/surrealist/ql/statements/create_statements.py
@@ -1,15 +1,16 @@
-import json
 from typing import Dict, Optional
 
 from surrealist.ql.statements.common_statements import CanUseReturn
 from surrealist.ql.statements.statement import FinishedStatement, Statement
 from surrealist.ql.statements.utils import combine
+from surrealist.utils import safe_dumps
 
 
 class Set(FinishedStatement, CanUseReturn):
     """
     Represents a SET clause for CREATE statements.
     """
+
     def __init__(self, statement: Statement, result: Optional[str] = None, **kwargs):
         super().__init__(statement)
         self._kw = kwargs
@@ -26,12 +27,13 @@ class Content(FinishedStatement, CanUseReturn):
     """
     Represents a CONTENT clause for CREATE statements.
     """
+
     def __init__(self, statement: Statement, content: Dict):
         super().__init__(statement)
         self._content = content
 
     def _clean_str(self):
-        args = json.dumps(self._content)
+        args = safe_dumps(self._content)
         return f"{self._statement._clean_str()} CONTENT {args}"
 
 

--- a/src/surrealist/ql/statements/define.py
+++ b/src/surrealist/ql/statements/define.py
@@ -451,7 +451,7 @@ class DefineField(Define, CanUsePermissions):
 
     Refer to: https://docs.surrealdb.com/docs/surrealql/statements/define/field
 
-    Example: https://github.com/kotolex/surrealist/blob/master/examples/surreal_ql/database.py
+    Example: https://github.com/kotolex/surrealist/blob/master/examples/surreal_ql/define_field.py
 
     DEFINE FIELD [ OVERWRITE | IF NOT EXISTS ] @name ON [ TABLE ] @table
     [ [ FLEXIBLE ] TYPE @type ]

--- a/src/surrealist/ql/statements/delete.py
+++ b/src/surrealist/ql/statements/delete.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 from surrealist.connections import Connection
-from surrealist.utils import OK
+from surrealist.utils import OK, StrOrRecord, get_table_or_record_id
 from .common_statements import CanUseWhere
 from .statement import Statement
 
@@ -21,19 +21,19 @@ class Delete(Statement, CanUseWhere):
     [ PARALLEL ];
     """
 
-    def __init__(self, connection: Connection, table_name: str, record_id: Optional[str] = None):
+    def __init__(self, connection: Connection, table_name: str, record_id: Optional[StrOrRecord] = None):
         super().__init__(connection)
         self._table_name = table_name
         self._only = False
         self._record_id = record_id
+        self._name = get_table_or_record_id(table_name, record_id)
 
     def validate(self) -> List[str]:
         return [OK]
 
     def _clean_str(self):
         only = "" if not self._only else " ONLY"
-        name = self._table_name if not self._record_id else f"{self._table_name}:{self._record_id}"
-        return f"DELETE{only} {name}"
+        return f"DELETE{only} {self._name}"
 
     def only(self) -> "Delete":
         """

--- a/src/surrealist/ql/statements/insert.py
+++ b/src/surrealist/ql/statements/insert.py
@@ -1,14 +1,9 @@
-import json
 from typing import List, Dict
 
 from surrealist.connections import Connection
 from surrealist.ql.statements.insert_statements import InsertUseDuplicate
 from surrealist.ql.statements.statement import Statement
-from surrealist.utils import OK
-
-"""
-
-"""
+from surrealist.utils import OK, safe_dumps
 
 
 class Insert(Statement, InsertUseDuplicate):
@@ -64,9 +59,9 @@ class Insert(Statement, InsertUseDuplicate):
     def _clean_str(self):
         args = self._args
         if len(args) == 1:
-            what = f"({args[0]._clean_str()})" if isinstance(args[0], Statement) else json.dumps(args[0])
+            what = f"({args[0]._clean_str()})" if isinstance(args[0], Statement) else safe_dumps(args[0])
         else:
             names = f"({', '.join(args[0])})"
-            data = ", ".join(str(e) for e in args[1:])
+            data = ", ".join(safe_dumps(e) for e in args[1:])
             what = f"{names} VALUES {data}"
         return f"INSERT INTO {self._table_name} {what}"

--- a/src/surrealist/ql/statements/select.py
+++ b/src/surrealist/ql/statements/select.py
@@ -1,7 +1,7 @@
 from typing import Optional, Tuple, Union, List
 
 from surrealist.connections import Connection
-from surrealist.utils import OK
+from surrealist.utils import OK, StrOrRecord, get_table_or_record_id
 from .select_statements import SelectUseIndex, SelectUseTempfiles
 from .statement import Statement, IterableStatement
 
@@ -69,13 +69,13 @@ class Select(IterableStatement, SelectUseIndex, SelectUseTempfiles):
         if self._value:
             self._what = f"VALUE {self._value}"
 
-    def by_id(self, record_id: str) -> "Select":
+    def by_id(self, record_id: StrOrRecord) -> "Select":
         """
-        Select table_name:record_id
+        Will select by given id SELECT @fields from table:record_id
 
         :param record_id: id of the record to select
         """
-        self._from = f"{self._table_name}:{record_id}"
+        self._from = get_table_or_record_id(self._table_name, record_id)
         return self
 
     def only(self) -> "Select":

--- a/src/surrealist/ql/statements/update.py
+++ b/src/surrealist/ql/statements/update.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from surrealist.connections import Connection
 from surrealist.ql.statements.statement import Statement
 from surrealist.ql.statements.update_statements import UpdateUseMethods
-from surrealist.utils import OK
+from surrealist.utils import OK, get_table_or_record_id
 
 
 class Update(Statement, UpdateUseMethods):
@@ -33,6 +33,7 @@ class Update(Statement, UpdateUseMethods):
         self._table_name = table_name
         self._only = False
         self._record_id = record_id
+        self._name = get_table_or_record_id(table_name, record_id)
 
     def validate(self) -> List[str]:
         return [OK]
@@ -46,5 +47,4 @@ class Update(Statement, UpdateUseMethods):
 
     def _clean_str(self):
         what = "" if not self._only else " ONLY"
-        table = self._table_name if not self._record_id else f"{self._table_name}:{self._record_id}"
-        return f"UPDATE{what} {table}"
+        return f"UPDATE{what} {self._name}"

--- a/src/surrealist/ql/statements/update_statements.py
+++ b/src/surrealist/ql/statements/update_statements.py
@@ -1,9 +1,9 @@
-import json
 from typing import Dict, List, Optional
 
 from surrealist.ql.statements.common_statements import CanUseWhere
 from surrealist.ql.statements.statement import FinishedStatement, Statement
 from surrealist.ql.statements.utils import combine
+from surrealist.utils import safe_dumps
 
 
 class Set(FinishedStatement, CanUseWhere):
@@ -41,7 +41,7 @@ class Patch(FinishedStatement, CanUseWhere):
         self._value = operations
 
     def _clean_str(self):
-        return f"{self._statement._clean_str()} PATCH {json.dumps(self._value)}"
+        return f"{self._statement._clean_str()} PATCH {safe_dumps(self._value)}"
 
 
 class Merge(FinishedStatement, CanUseWhere):
@@ -57,7 +57,7 @@ class Merge(FinishedStatement, CanUseWhere):
         self._value = value
 
     def _clean_str(self):
-        return f"{self._statement._clean_str()} MERGE {json.dumps(self._value)}"
+        return f"{self._statement._clean_str()} MERGE {safe_dumps(self._value)}"
 
 
 class Content(FinishedStatement, CanUseWhere):
@@ -73,7 +73,7 @@ class Content(FinishedStatement, CanUseWhere):
         self._value = value
 
     def _clean_str(self):
-        return f"{self._statement._clean_str()} CONTENT {json.dumps(self._value)}"
+        return f"{self._statement._clean_str()} CONTENT {safe_dumps(self._value)}"
 
 
 class UpdateUseMethods(CanUseWhere):

--- a/src/surrealist/ql/statements/upsert.py
+++ b/src/surrealist/ql/statements/upsert.py
@@ -24,6 +24,4 @@ class Upsert(Update):
     """
 
     def _clean_str(self):
-        what = "" if not self._only else " ONLY"
-        table = self._table_name if not self._record_id else f"{self._table_name}:{self._record_id}"
-        return f"UPSERT{what} {table}"
+        return f"UPSERT{super()._clean_str().lstrip('UPDATE')}"

--- a/src/surrealist/ql/statements/utils.py
+++ b/src/surrealist/ql/statements/utils.py
@@ -1,5 +1,6 @@
-import json
 from typing import Optional, Dict
+
+from surrealist.utils import safe_dumps
 
 
 def combine(result: Optional[str], kwargs: Dict) -> str:
@@ -12,6 +13,6 @@ def combine(result: Optional[str], kwargs: Dict) -> str:
     :return: string combined
     """
     first = result if result else ''
-    second = ", ".join(f"{k} = {json.dumps(v)}" for k, v in kwargs.items()) if kwargs else ''
+    second = ", ".join(f"{k} = {safe_dumps(v)}" for k, v in kwargs.items()) if kwargs else ''
     args = ', '.join(element for element in (first, second) if element)
     return args

--- a/src/surrealist/ql/table.py
+++ b/src/surrealist/ql/table.py
@@ -14,6 +14,7 @@ from surrealist.ql.statements.statement import Statement
 from surrealist.ql.statements.update import Update
 from surrealist.ql.statements.upsert import Upsert
 from surrealist.result import SurrealResult
+from surrealist.utils import StrOrRecord
 
 
 class Table:
@@ -75,7 +76,7 @@ class Table:
         """
         return Select(self._connection, self.name, *args, alias=alias, value=value)
 
-    def create(self, record_id: Optional[Union[str, int]] = None) -> Create:
+    def create(self, record_id: Optional[Union[StrOrRecord, int]] = None) -> Create:
         """
         Represent CREATE a statement and its abilities as refer here:
         https://docs.surrealdb.com/docs/surrealql/statements/create
@@ -104,7 +105,7 @@ class Table:
         """
         return Show(self._connection, self._name, since=since)
 
-    def delete(self, record_id: Optional[str] = None) -> Delete:
+    def delete(self, record_id: Optional[StrOrRecord] = None) -> Delete:
         """
         Represent DELETE statement
 
@@ -134,7 +135,7 @@ class Table:
     def drop(self) -> SurrealResult:
         """
         Fully removes table with all records in it if table exists.
-        This method never returns error, use IF EXISTS query
+        This method never returns error, cause use IF EXISTS query
 
         If you need to just delete all records and keep table - use **delete_all** method
 
@@ -145,7 +146,7 @@ class Table:
     def remove(self) -> SurrealResult:
         """
         Fully removes table with all records in it if table exists.
-        This method never returns error, use IF EXISTS query
+        This method never returns error, cause use IF EXISTS query
 
         If you need to just delete all records and keep table - use **delete_all** method
 
@@ -210,7 +211,7 @@ class Table:
         """
         return Insert(self._connection, self._name, *args)
 
-    def update(self, record_id: Optional[str] = None) -> Update:
+    def update(self, record_id: Optional[StrOrRecord] = None) -> Update:
         """
         Represent UPDATE object
 
@@ -226,7 +227,7 @@ class Table:
         """
         return Update(self._connection, self._name, record_id)
 
-    def upsert(self, record_id: Optional[str] = None) -> Upsert:
+    def upsert(self, record_id: Optional[StrOrRecord] = None) -> Upsert:
         """
         Represent UPSERT object
 
@@ -258,7 +259,7 @@ class Table:
         return RebuildIndex(self._connection, index_name=index_name, table_name=self._name, if_exists=if_exists)
 
     def __repr__(self):
-        return f"Table(name={self._name})"
+        return f"Table(name={self._name}, connection with {self._connection.transport().value} transport)"
 
     def __call__(self, *args, **kwargs):
         raise WrongCallError(f"Table object is not callable. \n"

--- a/src/surrealist/record_id.py
+++ b/src/surrealist/record_id.py
@@ -1,0 +1,76 @@
+from string import ascii_lowercase, digits
+from typing import Optional
+
+from surrealist.errors import SurrealRecordIdError
+
+ALPHABET = ascii_lowercase + digits
+
+
+class RecordId:
+    """
+    This class is a wrapper for record_id of SurrealDB
+
+    About record_ids: https://surrealdb.com/docs/surrealql/datamodel/ids
+    Refer to: https://github.com/kotolex/surrealist#Using_recordid
+    Examples: https://github.com/kotolex/surrealist/blob/master/examples/record_id.py
+    """
+
+    def __init__(self, id_: str, table: Optional[str] = None):
+        """
+        Wrapper for record_id
+        :param id_: full record_id like "table:id" or just "id" part of it. In the latter case, the table should be
+        specified
+        :param table: name of table, you can omit it if id_ is in full form (table:id)
+        :raises: SurrealRecordIdError on invalid id or table
+        """
+        if table is None and ":" not in id_:
+            raise SurrealRecordIdError("You need to specify table name or id like 'table:id'")
+        if table and ":" in table:
+            raise SurrealRecordIdError("Table name should not contain ':'")
+        if table and ":" in id_ and table != id_.split(":")[0]:
+            table_part = id_.split(":")[0]
+            raise SurrealRecordIdError(f"Table name is different from id, we expect {table}, but got {table_part}")
+        id_ = id_.replace("`", "").replace("⟨", "").replace("⟩", "")
+        self._naive_id = id_ if ":" in id_ else f"{table}:{id_}"
+        self._table_part, self._id_part = self._naive_id.split(":")
+        self._uid = f"{self._table_part}:⟨{self._id_part}⟩"
+
+    def __repr__(self):
+        return f"RecordId('{self._naive_id}')"
+
+    @property
+    def id_part(self) -> str:
+        return self._id_part
+
+    @property
+    def naive_id(self) -> str:
+        return self._naive_id
+
+    @property
+    def table_part(self) -> str:
+        return self._table_part
+
+    def to_valid_string(self) -> str:
+        """
+        Checks and adds special braces if id is not in simple form(a..zA..Z0-9), otherwise just returns naive_id
+        """
+        is_complicated_format = any(e not in ALPHABET for e in self._id_part.lower())
+        return self.to_uid_string() if is_complicated_format else self._naive_id
+
+    def to_prefixed_string(self) -> str:
+        """
+        Return record id with r prefix like r'table:id'
+        """
+        return f"r'{self._naive_id}'"
+
+    def to_uid_string(self) -> str:
+        """
+        Return record id with special braces for id like article:⟨c332eb25-e408-4396-814f-83a85d556493⟩
+        """
+        return self._uid
+
+    def to_uid_string_with_backticks(self) -> str:
+        """
+        Return record id with backticks for id like article:`c332eb25-e408-4396-814f-83a85d556493`
+        """
+        return self._uid.replace("⟨", "`").replace("⟩", "`")

--- a/src/surrealist/result.py
+++ b/src/surrealist/result.py
@@ -9,6 +9,8 @@ class SurrealResult:
     """
     Represents a result of the request both via http or websocket.
     Contains a few helpers to work with results of different kinds: id, ids, get, is_error, is_empty
+
+    Examples: https://github.com/kotolex/surrealist/blob/master/examples/result.py
     """
 
     def __init__(self, **kwargs):

--- a/src/surrealist/surreal.py
+++ b/src/surrealist/surreal.py
@@ -105,6 +105,8 @@ class Surreal:
         credentials parameters, so can raise exception if connect will fail. If this method succeeded, you are
         ready to go with SurrealDB
 
+        Examples: https://github.com/kotolex/surrealist/blob/master/examples/connect.py
+
         :return: connection object to work with SurrealDB
         :raise SurrealConnectionError: if cant connect with specified parameters
         """

--- a/src/surrealist/surreal.py
+++ b/src/surrealist/surreal.py
@@ -7,7 +7,7 @@ from surrealist.connections.connection import Connection
 from surrealist.connections.http_connection import HttpConnection
 from surrealist.connections.ws_connection import WebSocketConnection
 from surrealist.errors import HttpClientError, SurrealConnectionError, ConnectionParametersError
-from surrealist.utils import DEFAULT_TIMEOUT, _set_length, DATA_LENGTH_FOR_LOGS, ENCODING, OK, HTTP_OK, NS, DB, AC
+from surrealist.utils import DEFAULT_TIMEOUT, ENCODING, OK, HTTP_OK, NS, DB, AC
 
 logger = getLogger("surrealist")
 
@@ -41,7 +41,6 @@ class Surreal:
         It is strongly recommended to use websocket transport as it is more powerful.
         :param timeout: connection timeout in seconds
         """
-        self._log_data_length = DATA_LENGTH_FOR_LOGS
         self._client = HttpConnection if use_http else WebSocketConnection
         self.db_params = {}
         if namespace:
@@ -85,19 +84,6 @@ class Surreal:
             _url = urllib.parse.urlparse(url.lower())
             self._possible_url = f"{_url.scheme.replace('ws', 'http')}://{_url.netloc}/"
             logger.info("Predicted url is: %s", self._possible_url)
-
-    def set_log_length_for_data(self, length: int):
-        """
-        Setting maximum string length for object(json) in logs, it is not always desirable to see all data that comes
-        in and out in logs, because some objects(jsons) can be very large, but for debug purposes you can increase it
-        to see the full picture. However, it is not recommended to set length too small for speed reasons, or set it
-        too large, except when you are in the debug mode. Default is 300 chars, which is enough for standard
-        SurrealDB messages.
-
-        :param length: new maximum length for one string in logs
-        """
-        _set_length(length)
-        self._log_data_length = length
 
     def connect(self) -> Connection:
         """

--- a/src/surrealist/utils.py
+++ b/src/surrealist/utils.py
@@ -16,16 +16,10 @@ DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 DATE_FORMAT_NS = "%Y-%m-%dT%H:%M:%S.%fZ"
 HTTP_OK = 200  # status code for success
 DEFAULT_TIMEOUT = 15  # timeout in seconds for basic operations
-DATA_LENGTH_FOR_LOGS = 300  # size of data in logs, data will be cropped if bigger than that
 LOG_FORMAT = '%(asctime)s : %(threadName)s : %(name)s : %(levelname)s : %(message)s'  # use it for logs
 NS = "NS"
 DB = "DB"
 AC = "AC"
-
-
-def _set_length(length: int):
-    global DATA_LENGTH_FOR_LOGS
-    DATA_LENGTH_FOR_LOGS = length
 
 
 def get_uuid() -> str:
@@ -44,19 +38,6 @@ def mask_pass(text: str) -> str:
     :return: text without visible passwords
     """
     return re.sub(r"(?ms)(?<=['\"]pass['\"]: ['\"]).*?(?=['\"])", '******', text)
-
-
-def crop_data(data: Union[str, bytes], is_str: bool = True) -> Union[str, bytes]:
-    """
-    Crop the data to maximum size, no actions if data is smaller, work with str and bytes in logs
-
-    :param data: str or bytes of data to put it in the logs
-    :param is_str: a flag to use correct operation
-    :return: data of the same type, but cropped if it is bigger than DATA_LENGTH_FOR_LOGS
-    """
-    if len(data) > DATA_LENGTH_FOR_LOGS:
-        return f"{data[:DATA_LENGTH_FOR_LOGS]}..." if is_str else data[:DATA_LENGTH_FOR_LOGS] + b'...'
-    return data
 
 
 def to_surreal_datetime_str(dt: datetime.datetime) -> str:

--- a/src/surrealist/utils.py
+++ b/src/surrealist/utils.py
@@ -1,7 +1,13 @@
 import datetime
+import json
 import re
 import uuid
-from typing import Union
+from typing import Union, Dict, Optional, List, Tuple, Any
+
+from .errors import SurrealRecordIdError
+from .record_id import RecordId
+
+StrOrRecord = Union[str, RecordId]
 
 ENCODING = "UTF-8"
 OK = "OK"
@@ -82,3 +88,99 @@ def clean_dates(data: str) -> str:
     :return: data with valid Surreal dates
     """
     return re.sub(r'["\'](d(["\']).+?)["\']+', r'\1\2', data)
+
+
+def safe_dumps(data: Any) -> str:
+    """
+    Convert data to json string with special logic for RecordId (if it exists)
+    We have to do it because since version 2.0 of SurrealDB it never converts string to record_id
+    :param data: data to convert, dict, list, tuple or JSON serializable object expected here
+    :return: string
+    """
+    if isinstance(data, RecordId):
+        return data.to_valid_string()
+    if isinstance(data, List):
+        return list_to_json_str(data)
+    if isinstance(data, Tuple):
+        return tuple_to_json_str(data)
+    if isinstance(data, Dict):
+        return dict_to_json_str(data)
+    return json.dumps(data)
+
+
+def dict_to_json_str(data: Dict) -> str:
+    """
+    Convert dict to json string with special logic for RecordId (if it exists)
+    We have to do it because since version 2.0 of SurrealDB it never converts string to record_id
+    :param data: dict to convert
+    :return: string
+    """
+    ids = {k: v for k, v in data.items() if isinstance(v, (RecordId, List, Dict))}
+    if not ids:
+        return json.dumps(data)
+    without_ids = {k: v for k, v in data.items() if k not in ids}
+    first = json.dumps(without_ids) if without_ids else ""
+    join = ", ".join([f'"{k}": {safe_dumps(v)}' for k, v in ids.items()])
+    if first:
+        first = first.rstrip("}")
+        first = f"{first}, "
+    else:
+        first = "{"
+    return f"{first}{join}}}"
+
+
+def list_to_json_str(data: List) -> str:
+    """
+    Convert a list to json string with special logic for RecordId (if it exists)
+    We have to do it because since version 2.0 of SurrealDB it never converts string to record_id
+    :param data: list of pairs to convert
+    :return: string
+    """
+    ids = [e for e in data if isinstance(e, (RecordId, List, Dict, Tuple))]
+    if not ids:
+        return json.dumps(data)
+    without_ids = [e for e in data if e not in ids]
+    first = json.dumps(without_ids) if without_ids else ""
+    join = ", ".join(safe_dumps(e) for e in ids)
+    if first:
+        first = first.rstrip("]")
+        first = f"{first}, "
+    else:
+        first = "["
+    return f"{first}{join}]"
+
+
+def tuple_to_json_str(values: Tuple) -> str:
+    """
+    Convert a tuple to json string with special logic for RecordId (if it exists)
+    We have to do it because since version 2.0 of SurrealDB it never converts string to record_id
+    :param values: tuple to convert
+    :return: string
+    """
+    ids = [e for e in values if isinstance(e, (RecordId, List, Dict, Tuple))]
+    if not ids:
+        return f'({json.dumps(values).lstrip("[").rstrip("]")})'
+    without_ids = [e for e in values if e not in ids]
+    first = json.dumps(without_ids)
+    first = first.lstrip("[").rstrip("]")
+    if first:
+        first = f"{first}, "
+    join = ", ".join(f'{safe_dumps(e)}' for e in ids)
+    return f"({first}{join})"
+
+
+def get_table_or_record_id(table_name: str, record_id: Optional[StrOrRecord]) -> str:
+    """
+    A helper for backward compatibility and converting string to record_id
+    :param table_name: name of table
+    :param record_id: string or record_id
+    :return: valid record_id representation
+    """
+    if record_id is not None:
+        if isinstance(record_id, (str, int)):
+            record_id = RecordId(str(record_id), table=table_name)
+        part = record_id.table_part
+        if table_name != part:
+            raise SurrealRecordIdError(f"Table name is different from id, we expect {table_name}, but got {part}")
+        return record_id.to_valid_string()
+    return table_name

--- a/tests/integration_tests/test_pool.py
+++ b/tests/integration_tests/test_pool.py
@@ -14,7 +14,7 @@ class TestDatabasePool(TestCase):
     def test_check_pool(self):
         for use in (True, False):
             with self.subTest(f"check pool(use_http={use}"):
-                with DatabaseConnectionsPool(URL, 'test', 'test', credentials=('user_db', 'user_db'), use_http=True,
+                with DatabaseConnectionsPool(URL, 'test', 'test', credentials=('user_db', 'user_db'), use_http=use,
                                              min_connections=2, max_connections=10) as db:
                     self.assertEqual(text, str(db))
                     self.assertTrue("tables" in db.info())
@@ -24,8 +24,9 @@ class TestDatabasePool(TestCase):
                     self.assertEqual(2, db.min_connections)
                     self.assertEqual(10, db.max_connections)
                     self.assertEqual(2, db.connections_count)
-                    self.assertEqual("Table(name=person)", str(db.person))
-                    self.assertEqual("Table(name=person)", str(db.table("person")))
+                    res = 'http' if use else 'websocket'
+                    self.assertEqual(f"Table(name=person, connection with {res} transport)", str(db.person))
+                    self.assertEqual(f"Table(name=person, connection with {res} transport)", str(db.table("person")))
                     self.assertTrue(db.some_table.count() >= 0)
                     self.assertEqual(db.raw_query("Return 1;").result, 1)
                     self.assertEqual(db.returns("1").run().result, 1)

--- a/tests/integration_tests/test_ql_db.py
+++ b/tests/integration_tests/test_ql_db.py
@@ -9,23 +9,23 @@ from surrealist import Database, WrongCallError, Surreal, SurrealConnectionError
 class TestDatabase(TestCase):
     def test_via_http(self):
         with Database(URL, 'test', 'test', credentials=('user_db', 'user_db'), use_http=True) as db:
-            self.assertEqual("Database(namespace=test, name=test, connected=True)", str(db))
+            self.assertEqual("Database(namespace=test, name=test, connected=True, connection with http transport)", str(db))
             self.assertTrue("tables" in db.info())
             self.assertTrue(isinstance(db.tables(), List))
             self.assertEqual("test", db.name)
             self.assertEqual("test", db.namespace)
-            self.assertEqual("Table(name=person)", str(db.person))
-            self.assertEqual("Table(name=person)", str(db.table("person")))
+            self.assertEqual("Table(name=person, connection with http transport)", str(db.person))
+            self.assertEqual("Table(name=person, connection with http transport)", str(db.table("person")))
 
     def test_via_ws(self):
         with Database(URL, 'test', 'test', credentials=('user_db', 'user_db')) as db:
-            self.assertEqual("Database(namespace=test, name=test, connected=True)", str(db))
+            self.assertEqual("Database(namespace=test, name=test, connected=True, connection with websocket transport)", str(db))
             self.assertTrue("tables" in db.info())
             self.assertTrue(isinstance(db.tables(), List))
             self.assertEqual("test", db.name)
             self.assertEqual("test", db.namespace)
-            self.assertEqual("Table(name=person)", str(db.person))
-            self.assertEqual("Table(name=person)", str(db.table("person")))
+            self.assertEqual("Table(name=person, connection with websocket transport)", str(db.person))
+            self.assertEqual("Table(name=person, connection with websocket transport)", str(db.table("person")))
 
     def test_live_and_kill(self):
         a_list = []
@@ -81,7 +81,6 @@ class TestDatabase(TestCase):
             res = db.run_function("count")
             self.assertFalse(res.is_error())
             self.assertEqual(1, res.result)
-
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests/test_connections.py
+++ b/tests/unit_tests/test_connections.py
@@ -81,10 +81,8 @@ class TestConst(TestCase):
         self.assertFalse(res.is_error())
 
     def test_masked_opts(self):
-        res = mask_opts({"headers": {"Authorization": "Bearer 123456"}, "data": b'0' * 350, "method": "GET"})
-        self.assertEqual(res,
-                         {"headers": {"Authorization": "Bearer ******"}, "data": "b'" + "0" * 298 + "...",
-                          "method": "GET"})
+        res = mask_opts({"headers": {"Authorization": "Bearer 123456"}, "method": "GET"})
+        self.assertEqual(res, {"headers": {"Authorization": "Bearer ******"}, "method": "GET"})
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests/test_database.py
+++ b/tests/unit_tests/test_database.py
@@ -13,7 +13,7 @@ text = """BEGIN TRANSACTION;
 
 CREATE author CONTENT {"name": "john", "id": "john"};
 CREATE book CONTENT {"title": "Title", "author": "author:john"};
-UPDATE counter:author_count SET count +=1;
+UPDATE counter:authorcount SET count +=1;
 
 COMMIT TRANSACTION;"""
 
@@ -22,7 +22,7 @@ class TestDatabase(TestCase):
     def test_tr(self):
         create_author = Create(None, "author").content({"name": "john", "id": "john"})
         create_book = Create(None, "book").content({"title": "Title", "author": "author:john"})
-        counter_inc = Update(None, "counter", "author_count").set("count +=1")
+        counter_inc = Update(None, "counter", "authorcount").set("count +=1")
 
         transaction = Transaction(None, [create_author, create_book, counter_inc])
         self.assertEqual(text, transaction.to_str())

--- a/tests/unit_tests/test_ql_insert.py
+++ b/tests/unit_tests/test_ql_insert.py
@@ -1,11 +1,12 @@
 from unittest import TestCase, main
 
+from surrealist import RecordId
 from surrealist.ql.statements.insert import Insert
 from surrealist.ql.statements.select import Select
 
 
 class TestInsert(TestCase):
-    def test_delete_default(self):
+    def test_insert_default(self):
         data = {
             'name': 'SurrealDB',
             'founded': "2021-09-10",
@@ -17,25 +18,46 @@ class TestInsert(TestCase):
                          '["person:tobie", "person:jaime"], "tags": ["big data", "database"]};', insert.to_str())
         self.assertTrue(insert.is_valid())
 
+    def test_insert_with_record_id(self):
+        data = {
+            'name': 'SurrealDB',
+            'founded': RecordId("2021-09-10", "dates"),
+        }
+        insert = Insert(None, "person", data)
+        self.assertEqual('INSERT INTO person {"name": "SurrealDB", "founded": dates:⟨2021-09-10⟩};', insert.to_str())
+        self.assertTrue(insert.is_valid())
+
     def test_failed_no_args(self):
         with self.assertRaises(ValueError):
             Insert(None, "person")
 
+    def test_tuple_with_record_id_values(self):
+        text = 'INSERT INTO some (url, link) VALUES ("salesforce.com", vanse:⟨4ccfa3ce-fc31-4cd8-a239-384c26ec95c8⟩);'
+        record_id = RecordId('4ccfa3ce-fc31-4cd8-a239-384c26ec95c8', table='vanse')
+        record_id2 = RecordId('jhonny', table='vanse')
+        insert = Insert(None, "some", ("url", "link"), ('salesforce.com', record_id))
+        self.assertEqual(text, insert.to_str())
+        self.assertTrue(insert.is_valid())
+        text = 'INSERT INTO some (url, link) VALUES ("salesforce.com", vanse:⟨4ccfa3ce-fc31-4cd8-a239-384c26ec95c8⟩), ("other.com", vanse:jhonny);'
+        insert = Insert(None, "some", ("url", "link"), ('salesforce.com', record_id), ('other.com', record_id2))
+        self.assertEqual(text, insert.to_str())
+        self.assertTrue(insert.is_valid())
+
     def test_simple_values(self):
-        text = "INSERT INTO company (name, founded) VALUES ('SurrealDB', '2021-09-10');"
+        text = 'INSERT INTO company (name, founded) VALUES ("SurrealDB", "2021-09-10");'
         insert = Insert(None, "company", ("name", "founded"), ('SurrealDB', '2021-09-10'))
         self.assertEqual(text, insert.to_str())
         self.assertTrue(insert.is_valid())
 
     def test_more_values(self):
-        text = "INSERT INTO company (name, founded) VALUES ('Acme Inc.', '1967-05-03'), ('Apple Inc.', '1976-04-01');"
+        text = 'INSERT INTO company (name, founded) VALUES ("Acme Inc.", "1967-05-03"), ("Apple Inc.", "1976-04-01");'
         insert = Insert(None, "company", ("name", "founded"), ('Acme Inc.', '1967-05-03'),
                         ('Apple Inc.', '1976-04-01'))
         self.assertEqual(text, insert.to_str())
         self.assertTrue(insert.is_valid())
 
     def test_duplicate(self):
-        text = "INSERT INTO product (name, url) VALUES ('Salesforce', 'salesforce.com') ON DUPLICATE KEY UPDATE tags += 'crm';"
+        text = 'INSERT INTO product (name, url) VALUES ("Salesforce", "salesforce.com") ON DUPLICATE KEY UPDATE tags += \'crm\';'
         insert = Insert(None, "product", ("name", "url"), ('Salesforce', 'salesforce.com')).on_duplicate(
             "tags += 'crm'")
         self.assertEqual(text, insert.to_str())
@@ -46,6 +68,14 @@ class TestInsert(TestCase):
                '{"id": "person:tobie", "name": "Tobie", "surname": "Morgan Hitchcock"}];'
         data=  [{'id': "person:jaime", 'name': "Jaime", 'surname': "Morgan Hitchcock"},
                 {'id': "person:tobie", 'name': "Tobie", 'surname': "Morgan Hitchcock"} ]
+        insert = Insert(None, "person", data)
+        self.assertEqual(text, insert.to_str())
+        self.assertTrue(insert.is_valid())
+
+    def test_bulk_with_records(self):
+        text = 'INSERT INTO person [{"name": "Jaime", "id": person:jaime}, {"name": "Tobie", "id": person:tobie}];'
+        data = [{'id': RecordId("person:jaime"), 'name': "Jaime"},
+                {'id': RecordId("person:tobie"), 'name': "Tobie"}]
         insert = Insert(None, "person", data)
         self.assertEqual(text, insert.to_str())
         self.assertTrue(insert.is_valid())

--- a/tests/unit_tests/test_record_id.py
+++ b/tests/unit_tests/test_record_id.py
@@ -1,0 +1,49 @@
+from unittest import TestCase, main
+
+from surrealist.errors import SurrealRecordIdError
+from surrealist.utils import RecordId
+
+
+class TestRecordId(TestCase):
+    def test_create(self):
+        record_id = RecordId('person:tobie')
+        self.assertEqual(record_id.naive_id, "person:tobie")
+        self.assertEqual(record_id.id_part, "tobie")
+        self.assertEqual(record_id.table_part, "person")
+        self.assertEqual(record_id.to_prefixed_string(), "r'person:tobie'")
+        self.assertEqual(record_id.to_uid_string(), "person:⟨tobie⟩")
+        self.assertEqual(record_id.to_uid_string_with_backticks(), "person:`tobie`")
+        self.assertEqual(str(record_id), "RecordId('person:tobie')")
+
+    def test_create_with_table(self):
+        record_id = RecordId('tobie', table='person')
+        self.assertEqual(record_id.naive_id, "person:tobie")
+        self.assertEqual(record_id.id_part, "tobie")
+        self.assertEqual(record_id.table_part, "person")
+        self.assertEqual(record_id.to_prefixed_string(), "r'person:tobie'")
+        self.assertEqual(record_id.to_uid_string(), "person:⟨tobie⟩")
+        self.assertEqual(str(record_id), "RecordId('person:tobie')")
+
+    def test_raise_no_colon(self):
+        with self.assertRaises(SurrealRecordIdError):
+            RecordId('tobie')
+
+    def test_raise_different_tables(self):
+        with self.assertRaises(SurrealRecordIdError):
+            RecordId('person:tobie', table='tobie')
+
+    def test_raise_colon_in_table_name(self):
+        with self.assertRaises(SurrealRecordIdError):
+            RecordId('tobie', table='tobie:tobie')
+
+    def test_valid_form(self):
+        record_id = RecordId('person:tobie')
+        self.assertEqual(record_id.to_valid_string(), "person:tobie")
+        record_id = RecordId('person:100')
+        self.assertEqual(record_id.to_valid_string(), "person:100")
+        record_id = RecordId('person:8424486b-85b3-4448-ac8d-5d51083391c7')
+        self.assertEqual(record_id.to_valid_string(), "person:⟨8424486b-85b3-4448-ac8d-5d51083391c7⟩")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -1,7 +1,7 @@
 import datetime
 from unittest import TestCase, main
 
-from surrealist.utils import (to_datetime, to_surreal_datetime_str, crop_data, mask_pass, clean_dates,
+from surrealist.utils import (to_datetime, to_surreal_datetime_str, mask_pass, clean_dates,
                               dict_to_json_str,
                               RecordId, list_to_json_str, tuple_to_json_str)
 
@@ -14,12 +14,6 @@ class TestUtils(TestCase):
 
     def test_to_surreal_datetime_str(self):
         self.assertEqual(to_surreal_datetime_str(datetime.datetime(2018, 1, 1, 0, 0)), "d'2018-01-01T00:00:00.000000Z'")
-
-    def test_crop_same(self):
-        self.assertEqual(crop_data("one"), "one")
-
-    def test_crop_data(self):
-        self.assertEqual(crop_data("*" * 400), "*" * 300 + "...")
 
     def test_mask_pass(self):
         self.assertEqual(mask_pass(

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -1,7 +1,9 @@
 import datetime
 from unittest import TestCase, main
 
-from surrealist.utils import to_datetime, to_surreal_datetime_str, crop_data, mask_pass, clean_dates
+from surrealist.utils import (to_datetime, to_surreal_datetime_str, crop_data, mask_pass, clean_dates,
+                              dict_to_json_str,
+                              RecordId, list_to_json_str, tuple_to_json_str)
 
 
 class TestUtils(TestCase):
@@ -36,6 +38,31 @@ class TestUtils(TestCase):
         text = """CREATE z CONTENT {"name": "xxx", "age": 22, "create_time": 'd"2024-10-23T16:06:51.322496Z"'};"""
         expected = """CREATE z CONTENT {"name": "xxx", "age": 22, "create_time": d"2024-10-23T16:06:51.322496Z"};"""
         self.assertEqual(clean_dates(text), expected)
+
+    def test_dict_to_json_str(self):
+        self.assertEqual(dict_to_json_str({}), "{}")
+        self.assertEqual(dict_to_json_str({"a": 1}), '{"a": 1}')
+        self.assertEqual(dict_to_json_str({"a": 1, "b": 2}), '{"a": 1, "b": 2}')
+        self.assertEqual(dict_to_json_str({"a": 1, "b": RecordId("person:john"), "c": 3}), '{"a": 1, "c": 3, "b": person:john}')
+        self.assertEqual(dict_to_json_str({"b": RecordId("person:john"), "c": 3}), '{"c": 3, "b": person:john}')
+        self.assertEqual(dict_to_json_str({"b": RecordId("person:john")}), '{"b": person:john}')
+
+    def test_list_to_json_str(self):
+        self.assertEqual(list_to_json_str([]), "[]")
+        self.assertEqual(list_to_json_str([1, "2"]), '[1, "2"]')
+        self.assertEqual(list_to_json_str([1, RecordId("person:john")]), '[1, person:john]')
+        self.assertEqual(list_to_json_str([RecordId("person:john"), 1]), '[1, person:john]')
+        self.assertEqual(list_to_json_str([RecordId("person:john"), RecordId("person:tobie")]), '[person:john, person:tobie]')
+        self.assertEqual(list_to_json_str([1, [RecordId("person:john"), RecordId("person:tobie")]]), '[1, [person:john, person:tobie]]')
+
+    def test_tuple_to_json_str(self):
+        self.assertEqual(tuple_to_json_str(tuple()), "()")
+        self.assertEqual(tuple_to_json_str((1, None)), '(1, null)')
+        self.assertEqual(tuple_to_json_str((1, RecordId("person:john"))), '(1, person:john)')
+        self.assertEqual(tuple_to_json_str((RecordId("person:john"), 1)), '(1, person:john)')
+        self.assertEqual(tuple_to_json_str((RecordId("person:john"), RecordId("person:tobie"))), '(person:john, person:tobie)')
+        self.assertEqual(tuple_to_json_str((1, [RecordId("person:john"), RecordId("person:tobie")])), '(1, [person:john, person:tobie])')
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- add RecordId object
- add Transport enum
- rewrite README.md for record_id
- add type StrOrRecord
- add backward compartibility for all methods with string for record_id
- simplify UPSERT
- connections now store transport, database and table shows it on str()
- add tests
- add examples
- refactoring